### PR TITLE
Fixed STK World Terrain datasource listing and max zoomlevel.

### DIFF
--- a/terrain/stk-world-terrain.html
+++ b/terrain/stk-world-terrain.html
@@ -25,7 +25,7 @@ title: STK World Terrain
     <div class="columns-right">
         <a href="http://www.agi.com/" target="_blank"><img src="images/agi.png" width="64" height="24" style="border: none; vertical-align: bottom; margin-right: 10px;" alt="Analytical Graphics, Inc." title="Analytical Graphics, Inc." /></a>
         <br />
-        Copyright &copy; 2013-2015 Analytical Graphics, Inc. (AGI).  All Rights Reserved.  This tileset may not be copied or used except under the terms described in the <a href="#TermsOfUse">Terms of Use</a> or by a separate written agreement with AGI.
+        Copyright &copy; 2013-2016 Analytical Graphics, Inc. (AGI).  All Rights Reserved.  This tileset may not be copied or used except under the terms described in the <a href="#TermsOfUse">Terms of Use</a> or by a separate written agreement with AGI.
         <br />
         Please send any feedback on this tileset to <a href="mailto:todd@agi.com">todd@agi.com</a>.
     </div>
@@ -58,7 +58,7 @@ title: STK World Terrain
 </div>
 <div class="columns">
     <div class="columns-left">Maximum Level:</div>
-    <div class="columns-right">16</div>
+    <div class="columns-right">15</div>
 </div>
 <div class="columns">
     <div class="columns-left">Tile Format:</div>
@@ -113,7 +113,7 @@ scene.terrainProvider = new Cesium.CesiumTerrainProvider({
     <tr>
         <td><a href="http://ned.usgs.gov">National Elevation Dataset (NED)<a></td>
         <td>United States</td>
-        <td>3 meters to 30 meters</td>
+        <td>10 meters to 30 meters</td>
     </tr>
     <tr>
         <td><a href="http://www.eea.europa.eu/data-and-maps/data/eu-dem#tab-original-data">EU-DEM</a></td>
@@ -121,8 +121,8 @@ scene.terrainProvider = new Cesium.CesiumTerrainProvider({
         <td>30 meters</td>
     </tr>
     <tr>
-        <td><a href="http://www.ga.gov.au/metadata-gateway/metadata/record/gcat_72759">Australia SRTM-derived 1 Second DEM</a></td>
-        <td>Australia</td>
+        <td><a href="https://lta.cr.usgs.gov/SRTM1Arc">USGS SRTM 1 Second Global</a></td>
+        <td>Approximately -60 to 60 degrees latitude</td>
         <td>30 meters</td>
     </tr>
     <tr>
@@ -145,7 +145,7 @@ scene.terrainProvider = new Cesium.CesiumTerrainProvider({
 <ul>
     <li>You may not copy, store, or redistribute any portion of the tileset for use in an offline, disconnected, or local environment.  Client-side and proxy-based caching are allowed as long as it is a general caching mechanism caching other internet traffic as well, not just STK World Terrain data.</li>
     <li>You may not put an unreasonable burden on the STK World Terrain server(s).  If you're concerned that your use may be deemed unreasonable, please <a href="mailto:todd@agi.com">contact AGI</a> to discuss it.</li>
-    <li>You must clearly display the attribution for this dataset, "&copy; Analytical Graphics, Inc., &copy; CGIAR-CSI, Produced using Copernicus data and information funded by the European Union - EU-DEM layers, &copy; Commonwealth of Australia (Geoscience Australia) 2012", any time any portion of the tileset is visible.</li>
+    <li>You must clearly display the attribution for this dataset, "&copy; Analytical Graphics, Inc., &copy; CGIAR-CSI, Produced using Copernicus data and information funded by the European Union - EU-DEM layers</li>
     <li>You agree that STK World Terrain is provided as-is and at-will, and will not hold AGI responsible for anything bad that happens as a result of your use of the tileset or your inability to use the tileset.  While AGI does not foresee doing so, AGI reserves the right to shut it down at any time, with or without notice.</li>
     <li>You agree that these terms of use may change at any time, and that your continued use of the tileset constitutes acceptance of the new terms.</li>
 </ul>


### PR DESCRIPTION
The datasources listed on our STK World Terrain page are out of date.  We no longer incorporate the Australia SRTM derived.  This has been replaced with the 30m SRTM from USGS.  Also, the maximum zoom level is now level 15 for this tileset.